### PR TITLE
quark file: add full GitHub path to ExtraWindows dependency.

### DIFF
--- a/SignalBox.quark
+++ b/SignalBox.quark
@@ -7,6 +7,6 @@
        \version: "0.1.0",
         \schelp: "The SignalBox Toolset",
            \url: "https://github.com/ambisonictoolkit/SignalBox",
-  \dependencies: [ "ExtraWindows" ],
+  \dependencies: [ "https://github.com/khoin/ExtraWindows" ],
          \since: "2019",
 )


### PR DESCRIPTION
Adding the full path of a quark on the dependency list will make the quark installer automagically install that dependency. The quark name alone won't install unless it's on the official quark repo list.