### PR TITLE
Fix Signal:-read numFrames calculation

### DIFF
--- a/Classes/extSignal.sc
+++ b/Classes/extSignal.sc
@@ -116,7 +116,7 @@
 			soundFile.openRead;
 
 			// calcs...
-			soundFrames = (soundFile.numFrames / soundFile.numChannels).asInteger;
+			soundFrames = soundFile.numFrames;
 			soundEndFrame = soundFrames - 1;
 			winSize = (size == nil).if({  // returned window size
 				soundFrames  // complete soundfile


### PR DESCRIPTION
It looks like `Signal:-read` assumes that `SoundFile:-numFrames` is returning the number of samples in a sound file, when it's in fact returning the number of frames (samples per channel).

```supercollider
(
// generate 3 harmonics, one on each channel

s.waitForBoot({
	var nchans = 3;
	var size = 512;

	x = nchans.collect{ |i|
		Signal.sineFill(size, [0,0,0].put(i, 1))
	};
	b = Buffer.loadCollection(s, x.flop.flat, 3, action: { "buffer loaded".postln });
})

)

// view the buffer
b.plot
// write the buffer to a temp soundfile
b.write(PathName.tmp +/+ "multichan_test.wav", "wav", "float");

// read the soundfile as a Signal
// read only half of it to see if it retrieves the correct frames
// first half-cycle of first channel
~sig = Signal.read(PathName.tmp +/+ "multichan_test.wav", size: 256, startFrame: 0, channel: 0);
~sig.plot // -> :-(
// second half-cycle of first channel
~sig = Signal.read(PathName.tmp +/+ "multichan_test.wav", size: 256, startFrame: 256, channel: 0);
~sig.plot // -> :-(
```